### PR TITLE
Stop counting keyword arguments when checking for too many parameters

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -96,6 +96,7 @@ Metrics/ParameterLists:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: true
   Max: 3
+  CountKeywordArgs: false
 
 Metrics/AbcSize:
   Description: >-

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2127,6 +2127,8 @@ this rule only to arrays with two or more elements.
 
 * Avoid parameter lists longer than three or four parameters.
 
+* Use keyword arguments when serializing parameters from a passed-in hash.
+
 * If you really need "global" methods, add them to Kernel and make them private.
 
 * Use module instance variables instead of global variables.


### PR DESCRIPTION
Discussion from elsewhere


> Rubocop has a check for methods with too many parameters, which is generally a good rule because having a long list of parameters makes it a lot harder to remember (a) what to include and (b) what order to include it in.
> 
> The problem is that we still tend to get into scenarios where we need to pass more than 3 pieces of information, and the typical course of action ends up being to package up a bunch of things into a hash, pass that into the method, and then unpack it. This is a little better than having a long list of parameters in that you don't have to worry about the order, but it loses all validation that the correct information was included along the way.
> 
> Keyword arguments are order agnostic and still allow for input validation, so everybody wins.

> So here's my feeling on this. Limiting arg count is a way of limiting the overall possible complexity of the method, which is good. My main issue is applying it to the initialize method. If classes are our data structures, it seems kind of odd to limit them to 3 pieces of data, which isn't really accurate given the scenario mentioned above. It's arguable that passing in an options hash is less clear when reading the method definition.
> 
> I'm alright with this change, but if someone has a more comprehensive way to attack this problem, I'm all ears.